### PR TITLE
Install CAcert in to systems certificates store

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Here is a list of all the default variables for this role, which are also availa
 #   - { name: 'foobar.com', country: 'DE', state: 'Bavaria', city: 'Munich', organization: 'Foo Bar', unit: '', email: 'foo@bar.com', days: 3650 }
 #
 
+# should we import cacert.org
+openssl_cacert_import: no
 # keys to import
 openssl_keys: []
 # certificates to import

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,8 @@
 #   - { name: 'foobar.com', country: 'DE', state: 'Bavaria', city: 'Munich', organization: 'Foo Bar', unit: '', email: 'foo@bar.com', days: 3650 }
 #
 
+# should we import cacert.org
+openssl_cacert_import: no
 # keys to import
 openssl_keys: []
 # certificates to import

--- a/tasks/cacert.yml
+++ b/tasks/cacert.yml
@@ -1,0 +1,25 @@
+---
+# Manually generated fingerprints as http://www.cacert.org/index.php?id=3
+# doesn't list them.
+
+- name: Create directory for cacert certificates
+  file: recurse=yes group=root owner=root state=directory
+    path=/usr/local/share/ca-certificates/cacert.org/
+
+- name: Download CAcert Class 1 PKI key
+  get_url:
+    dest=/usr/local/share/ca-certificates/cacert.org/
+    url=http://www.cacert.org/certs/root.crt
+    sha256shum='c0e0773a79dceb622ef6410577c19c1e177fb2eb9c623a49340de3c9f1de2560'
+
+- name: Download CAcert Class 3 PKI key
+  get_url:
+    dest=/usr/local/share/ca-certificates/cacert.org/
+    url=http://www.cacert.org/certs/class3.crt
+    sha256sum='f5badaa5da1cc05b110a9492455a2c2790d00c7175dcf3a7bcb5441af71bf84f'
+
+# Don't run if the cert has already been installed
+- name: Update ca certificates to enable CAcert
+  command: update-ca-certificates
+    creates=/etc/ssl/certs/cacert.org.pem
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
 
 - include: install.yml
+- include: cacert.yml
+  when: openssl_cacert_import
+
 - include: create.yml
 - include: copy.yml


### PR DESCRIPTION
CAcert is already available on Debian and Ubuntu releases (until those starting
in 2014) but this will allow downloading the certs on any system - including
those in the future.

Arguably this could go in its own role - I'm not sure if it should or not at
this stage.
