### PR TITLE
Add support for pre configuring openssl

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,3 +20,13 @@ openssl_certs_path: /etc/ssl/certs
 openssl_keys_path: /etc/ssl/private
 # self signed certificates
 openssl_self_signed: []
+
+# Change defaults for key generation for ALL users of the server
+openssl_cnf_default_bits: 2048
+openssl_cnf_dn_country: DE
+openssl_cnf_dn_state: Bavaria
+openssl_cnf_dn_locality: Munich
+openssl_cnf_dn_organisation: ''
+openssl_cnf_dn_organisational_unit: ''
+openssl_cnf_dn_common_name: ''
+

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,0 +1,58 @@
+---
+
+# Configure OpenSSL defaults relating to key generation.
+
+- name: Set default key length
+  lineinfile: state=present
+    dest=/etc/ssl/openssl.cnf
+    regexp='default_bits .*'
+    line='default_bits        = {{ openssl_cnf_default_bits }}'
+
+- name: Set default for country in Distinguished Name
+  lineinfile: create=no state=present
+    insertafter="^\[ req_distinguished_name \]$"
+    dest=/etc/ssl/openssl.cnf
+    regexp='^C .*'
+    line='C                       = "{{ openssl_cnf_dn_country }}"'
+  when: openssl_cnf_dn_country != ''
+
+- name: Set default for state in Distinguished Name
+  lineinfile: create=no state=present
+    insertafter="^\[ req_distinguished_name \]$"
+    dest=/etc/ssl/openssl.cnf
+    regexp='^ST .*'
+    line="ST                      = {{ openssl_cnf_dn_state }}"
+  when: openssl_cnf_dn_state != ''
+
+- name: Set default for locality in Distinguished Name
+  lineinfile: create=no state=present
+    insertafter="^\[ req_distinguished_name \]$"
+    dest=/etc/ssl/openssl.cnf
+    regexp='^L .*'
+    line="L                       = {{ openssl_cnf_dn_locality }}"
+  when: openssl_cnf_dn_locality != ''
+
+- name: Set default for organisation in Distinguished Name
+  lineinfile: create=no state=present
+    insertafter="^\[ req_distinguished_name \]$"
+    dest=/etc/ssl/openssl.cnf
+    regexp='^O .*'
+    line="O                       = {{ openssl_cnf_dn_organisation }}"
+  when: openssl_cnf_dn_organisation != ''
+
+- name: Set default for organisational unit in Distinguished Name
+  lineinfile: create=no state=present
+    insertafter="^\[ req_distinguished_name \]$"
+    dest=/etc/ssl/openssl.cnf
+    regexp='^OU .*'
+    line="OU                      = {{ openssl_cnf_dn_organisational_unit }}"
+  when: openssl_cnf_dn_organisational_unit != ''
+
+- name: Set default for common name in Distinguished Name
+  lineinfile: create=no state=present
+    insertafter="^\[ req_distinguished_name \]$"
+    dest=/etc/ssl/openssl.cnf
+    regexp='^CN .*'
+    line="CN                      = {{ openssl_cnf_dn_common_name }}"
+  when: openssl_cnf_dn_common_name != ''
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 
 - include: install.yml
+- include: configure.yml
 - include: create.yml
 - include: copy.yml


### PR DESCRIPTION
It can be handy to set all the configuration for openssl once (particularly key
length) rather then passing in options to openssl every time so this will
adjust the values modified as part of key generation - key length and
req_distinguished_name.

Arguably lthese variables duplicate those used for key generations in
tasks/create but they serve a different purpose as they are passed in to a
command which could be run with almost arbitrary parameters.
