### PR TITLE
Create directories for certificates

### DIFF
--- a/tasks/create.yml
+++ b/tasks/create.yml
@@ -5,8 +5,8 @@
     recurse=yes state=directory
     path={{ item }}
   with_items:
-    - {{ openssl_keys_path }}
-    - {{ openssl_certs_path }}
+    - "{{ openssl_keys_path }}"
+    - "{{ openssl_certs_path }}"
 
 - name: Creating self-signed server SSL cert
   command: >


### PR DESCRIPTION
If non standard (say per service) directories are configured but don't exist
certificate generation will fail. This creates the directories before certs are
generated.
