### PR TITLE
Add support for installing openssl on RedHat systems

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,8 +1,21 @@
 ---
 
-- name: Installing packages
+- name: Installing packages for Debian
+  when: ansible_os_family == 'Debian'
   apt: >
     pkg={{ item }}
+    state=present
+  with_items:
+    - openssl
+  tags:
+    - system
+    - openssl
+    - install
+
+- name: Installing packages for RedHat
+  when: ansible_os_family == 'RedHat'
+  yum: >
+    name={{ item }}
     state=present
   with_items:
     - openssl


### PR DESCRIPTION
This support means the role will run through correctly on RedHat based systems.
I'm adding support for RedHat to several of my roles and this is the first
problem I've encountered which couldn't be skipped over.
